### PR TITLE
fixed: added application environment check

### DIFF
--- a/src/WriteupServiceProvider.php
+++ b/src/WriteupServiceProvider.php
@@ -7,6 +7,28 @@ use Illuminate\Support\ServiceProvider;
 
 class WriteupServiceProvider extends ServiceProvider
 {
+
+
+    /**
+     * check if writeup is enabled for logging
+     * @return bool
+     */
+
+    protected function isWriteupEnabled()
+    {
+        $writeup_enabled = config('writeup.run_in_production');
+        $app_environment_name = config('app.env');
+
+        if (
+            $app_environment_name === "production" && $writeup_enabled ||
+            $app_environment_name && $writeup_enabled
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+    
     /**
      * @param Router $router
      */
@@ -19,7 +41,7 @@ class WriteupServiceProvider extends ServiceProvider
         }
 
 
-        if (config('writeup.run_in_production')) {
+        if ($this->isWriteupEnabled()) {
             if (config('writeup.request_log.enable')) {
                 $router->pushMiddlewareToGroup('api', WriteupRequestMiddleware::class);
                 $router->pushMiddlewareToGroup('web', WriteupRequestMiddleware::class);


### PR DESCRIPTION
I have some analysis. Suppose I have two variable one is `APP_ENV` and another one is `WRITEUP_RUN_IN_PRODUCTION`. Four situations could be rise here. 
| APP_ENV name   |      WRITEUP_RUN_IN_PRODUCTION      |  OUTPUT OF WRITEUP LOG |
|----------|:-------------:|------:|
| production | true | enabled |
| production | false | disabled |
| dev/local/any other name | true | enabled |
| dev/local/any other name | false | disabled |

I hope this analysis solves the bug. And I have implemented this condition for issue #1.